### PR TITLE
fixed deprecation warning for pygments config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 permalink: none
-pygments: true
+highlighter: pygments
 safe: true
 markdown: kramdown
 exclude: ['bootstrap','Gruntfile.js','node_modules','npm-debug.log','package.json','README.md','source']


### PR DESCRIPTION
Fixes:

Configuration file: /Users/xtof/Workspace/fri3d/www.fri3d.be/_config.yml
       Deprecation: The 'pygments' configuration option has been renamed to 'highlighter'. Please update your config file accordingly. The allowed values are 'rouge', 'pygments' or null.
